### PR TITLE
workaround for Shelly H&T 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The library also offers a index-dummy.js which offers the same interface then th
 
 ## Changelog
 
+### v1.0.2 (2018.12.30)
+* check if payload is identical. Work around for Shelly H&T with equal serial numbers in messages with new payload 
+
 ### v1.0.1 (2018.11.11)
 * fix online flag, finally
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class ShellyIot extends EventEmitter {
             this.emit('device-connection-status', deviceId, false);
         }, this.knownDevices[deviceId].validity * 1000);
 
-        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial && JSON.stringify(this.knownDevices[deviceId].lastPayload) === JSON.stringify(payload) {
+        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial && JSON.stringify(this.knownDevices[deviceId].lastPayload) === JSON.stringify(payload)) {
             this.logger && this.logger('CoAP data ignored: ' + JSON.stringify(options) + ' / ' + JSON.stringify(payload));
             if (!lastOnlineStatus) this.emit('device-connection-status', deviceId, true);
             return;

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ class ShellyIot extends EventEmitter {
             this.knownDevices[deviceId] = {
                 'validity': 0,
                 'lastSerial': 0,
+                'lastPayload': null,
                 'offlineTimer': null,
                 'online': false,
                 'ip': '',
@@ -125,12 +126,15 @@ class ShellyIot extends EventEmitter {
             this.emit('device-connection-status', deviceId, false);
         }, this.knownDevices[deviceId].validity * 1000);
 
-        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial) {
+        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial && JSON.stringify(this.knownDevices[deviceId].lastPayload) === JSON.stringify(payload) {
             this.logger && this.logger('CoAP data ignored: ' + JSON.stringify(options) + ' / ' + JSON.stringify(payload));
             if (!lastOnlineStatus) this.emit('device-connection-status', deviceId, true);
             return;
         }
-        if (options['3420']) this.knownDevices[deviceId].lastSerial = options['3420'];
+        if (options['3420']) {
+            this.knownDevices[deviceId].lastSerial = options['3420'];
+            this.knownDevices[deviceId].lastPayload = payload;
+        }
 
         this.logger && this.logger('CoAP status package received: ' + JSON.stringify(options) + ' / ' + JSON.stringify(payload));
         if (emit) this.emit('update-device-status', deviceId, payload);

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class ShellyIot extends EventEmitter {
         this.knownDevices[deviceId].online = true;
 
         let payload = req.payload.toString();
+
         if (!payload.length) {
             this.logger && this.logger('CoAP payload empty: ' + JSON.stringify(options));
             return;
@@ -126,14 +127,15 @@ class ShellyIot extends EventEmitter {
             this.emit('device-connection-status', deviceId, false);
         }, this.knownDevices[deviceId].validity * 1000);
 
-        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial && JSON.stringify(this.knownDevices[deviceId].lastPayload) === JSON.stringify(payload)) {
+        const payloadstr = JSON.stringify(payload);
+        if (this.knownDevices[deviceId].description && options['3420'] && options['3420'] === this.knownDevices[deviceId].lastSerial && this.knownDevices[deviceId].lastPayload === payloadstr) {
             this.logger && this.logger('CoAP data ignored: ' + JSON.stringify(options) + ' / ' + JSON.stringify(payload));
             if (!lastOnlineStatus) this.emit('device-connection-status', deviceId, true);
             return;
         }
         if (options['3420']) {
             this.knownDevices[deviceId].lastSerial = options['3420'];
-            this.knownDevices[deviceId].lastPayload = payload;
+            this.knownDevices[deviceId].lastPayload = payloadstr;
         }
 
         this.logger && this.logger('CoAP status package received: ' + JSON.stringify(options) + ' / ' + JSON.stringify(payload));
@@ -144,7 +146,7 @@ class ShellyIot extends EventEmitter {
 
     listen(callback) {
         this.coapServer = coap.createServer({
-        	multicastAddress: '224.0.1.187'
+            multicastAddress: '224.0.1.187'
         });
 
         this.coapServer.on('request', (req, res) => {
@@ -172,14 +174,14 @@ class ShellyIot extends EventEmitter {
             multicast: true,
             multicastTimeout: 500
         });
-/*        req.on('response', (res) => {
-            this.logger && this.logger('multicast response');
-            res.pipe(process.stdout);
-            res.on('end', () => {
-                console.log(res.options);
-                console.log(res.payload);
-            });
-        });*/
+        /*        req.on('response', (res) => {
+                    this.logger && this.logger('multicast response');
+                    res.pipe(process.stdout);
+                    res.on('end', () => {
+                        console.log(res.options);
+                        console.log(res.payload);
+                    });
+                });*/
         req.end();
         callback && callback();
     }
@@ -363,10 +365,10 @@ class ShellyIot extends EventEmitter {
             parameters = undefined;
         }
         var data = {
-            'parameters':    parameters,
+            'parameters': parameters,
             'requestConfig': {
-                'timeout':   1000, //request timeout in milliseconds
-                'noDelay':   true, //Enable/disable the Nagle algorithm
+                'timeout': 1000, //request timeout in milliseconds
+                'noDelay': true, //Enable/disable the Nagle algorithm
                 'keepAlive': false //Enable/disable keep-alive functionalityidle socket.
                 //keepAliveDelay: 1000 //and optionally set the initial delay before the first keepalive probe is sent
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "shelly-iot",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Library to communicate with Shelly.io devices",
     "keywords": [
         "shelly"

--- a/test.js
+++ b/test.js
@@ -1,3 +1,0 @@
-let a = { h: 1 };
-let b = { h: 2 };
-console.log(JSON.stringify(a) === JSON.stringify(b));

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+let a = { h: 1 };
+let b = { h: 2 };
+console.log(JSON.stringify(a) === JSON.stringify(b));


### PR DESCRIPTION
Shelly H&T sends messages with different payload with the same serial number. Additional check if payload changed by identical serial number. 