### PR TITLE
Add option to set a specific multicast interface for COAP-server

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,8 @@ class ShellyIot extends EventEmitter {
 
     listen(callback) {
         this.coapServer = coap.createServer({
-            multicastAddress: '224.0.1.187'
+            multicastAddress: '224.0.1.187',
+            multicastInterface: this.options.multicastInterface || null
         });
 
         this.coapServer.on('request', (req, res) => {


### PR DESCRIPTION
This patch allows to set the option multicastInterface in the constructor to a specific interface, e.g. "192.168.0.1". Otherwise the COAP-Server fails when there is more than one IP-Address on a physical interface (IP-Aliases), as there can only be one multicast-listener for any given physical interface. When option is not used, nothing changes. With this patch iobroker.shelly can be changed next to work on interfaces with IP-Aliases and COAP (Adapter fails to start right now).
Please review patch: I'm just new to iobroker and not a fluent javascript programmer.